### PR TITLE
Main pages find()

### DIFF
--- a/client/main.html
+++ b/client/main.html
@@ -41,7 +41,7 @@
 				<a href="/Search"><input id="search" type="text" class="form-control" placeholder="Search..."></a>
 				<div class="input-group-btn">
 				  <a href="/Search">
-					<button class="btn btn-default" type="submit">
+					<button class="btn btn-default" type="submit" onkeyup="searchFunction()">
 						<i class="glyphicon glyphicon-search"></i>
 					</button>
 				  </a>

--- a/client/main.js
+++ b/client/main.js
@@ -197,36 +197,26 @@ Template.newsfeed.helpers({
 	}
 });
 Template.general.helpers({
-    topics(){
-	return Topics.find({}, {sort:{createdAt: -1}, limit:Session.get("topicLimit")}); 
+	topics(){
+		return Topics.find({category: 'General'}, {sort:{createdAt: -1}, limit:Session.get("topicLimit")}); 
 	}
 });
 Template.instruments.helpers({
     topics(){
-	return Topics.find({}, {sort:{createdAt: -1}, limit:Session.get("topicLimit")}); 
+	return Topics.find({category: 'Instruments'}, {sort:{createdAt: -1}, limit:Session.get("topicLimit")}); 
 	}
 });
 Template.theory.helpers({
     topics(){
-	return Topics.find({}, {sort:{createdAt: -1}, limit:Session.get("topicLimit")}); 
+	return Topics.find({category: 'Theory'}, {sort:{createdAt: -1}, limit:Session.get("topicLimit")}); 
 	}
 });
 Template.buddybands.helpers({
     topics(){
-	return Topics.find({}, {sort:{createdAt: -1}, limit:Session.get("topicLimit")}); 
+	return Topics.find({category: 'BuddyBands'}, {sort:{createdAt: -1}, limit:Session.get("topicLimit")}); 
 	}
 });
-/*
-		Router.go('/Search', {
-			template: 'search',
-			data: function(){
-				var currentList = this.params._id;
-				return Topics.findOne({ _id: currentList });
-				var currentCategory = this.params.category;
-				return Topics.findOne({ category: currentCategory });
-			}
-		});
-*/
+
 /* Here we still need to sort only the comments of this very topic */
 Template.commentfeed.helpers({
 	comments: function () {
@@ -260,7 +250,9 @@ Template.comment.helpers({
 	}
 });
 
+/*
 
+*/
 
 		/* Here are the events for the templates */
 		


### PR DESCRIPTION
Managed to set the topics find() query for each of the mainpages to their respective category, but this brings some major issues :
- the search engine searches onlys in the titles, not in the description, either the category (must check last changes)
- it seems that not all topics are rendered (I think I have created more musicbuddy topics and only two are rendered on that tab)